### PR TITLE
fix #22: Close Git object

### DIFF
--- a/src/main/java/RepoSnapshot.java
+++ b/src/main/java/RepoSnapshot.java
@@ -54,10 +54,14 @@ public class RepoSnapshot {
         clone.setURI(url);
         Git git = clone.call();
 
-        CheckoutCommand checkout = git.checkout();
-        checkout.setName(commitHash);
-        checkout.setCreateBranch(false);
-        checkout.call();
+        try {
+            CheckoutCommand checkout = git.checkout();
+            checkout.setName(commitHash);
+            checkout.setCreateBranch(false);
+            checkout.call();
+        } finally {
+            git.close();
+        }
 
         return repoDir;
     }


### PR DESCRIPTION
Resolves #22.

The Git object must be closed before exiting, otherwise there will
still exist an active handler which causes exceptions when trying to
remove the temporary directory containing the repo. This bug caused
failures of two tests executed on Windows machines.